### PR TITLE
ci(discord): notify workflows staus to discord

### DIFF
--- a/.github/workflows/discord-notify-deploy.yml
+++ b/.github/workflows/discord-notify-deploy.yml
@@ -1,0 +1,19 @@
+# https://github.com/marketplace/actions/discord-webhook-action
+
+name: Discord Notify Deploy
+on: deployment
+
+jobs:
+  discord-notify-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Discord Webhook Action
+        uses: tsickert/discord-webhook@v6.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL_WORKFLOW }}
+          embed-title: "[${{ github.repository }}] Deploy ${{ github.event.deployment.environment }}"
+          embed-description: "Target: ${{ github.repository }}/${{ github.event.workflow_run.head_branch }}\nDeploy: ${{ github.event.deployment.environment }} ${{ github.event.workflow_run.conclusion }}${{ job.status == 'success' && '✅' || job.status == 'failure' && '🛑' || '🟨' }}\nActor: ${{ github.event.deployment.creator }}\n${{github.event.deployment.description}}"
+          embed-color: ${{ job.status == 'success' && '2278750' || job.status == 'failure' && '15680580' || '15381256' }}

--- a/.github/workflows/discord-notify-workflow.yml
+++ b/.github/workflows/discord-notify-workflow.yml
@@ -1,0 +1,24 @@
+# https://github.com/marketplace/actions/discord-webhook-action
+
+name: Discord Notify Workflow
+on:
+  workflow_run:
+    workflows: ["Lint"]
+    types: [requested, completed]
+    branches:
+      - "*"
+
+jobs:
+  discord-notify-workflow:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Discord Webhook Action
+        uses: tsickert/discord-webhook@v6.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL_WORKFLOW }}
+          embed-title: "[${{ github.repository }}] Workflow ${{ github.event.workflow_run.name }} ${{ github.event.workflow_run.conclusion }}: ${{ github.event.workflow_run.pull_requests.number || github.event.workflow_run.head_branch }}"
+          embed-description: "Target: ${{ github.repository }}/${{ github.event.workflow_run.head_branch }}\nWorkflow: ${{ github.event.workflow_run.name }} | ${{ github.event.workflow_run.conclusion }} ${{ job.status == 'success' && '✅' || job.status == 'failure' && '🛑' || '🟨' }}\nEvent: ${{ github.event.workflow_run.event }}\nActor: ${{ github.event.workflow_run.actor }}"
+          embed-color: ${{ job.status == 'success' && '2278750' || job.status == 'failure' && '15680580' || '15381256' }}


### PR DESCRIPTION
## Description

notify workflows staus to discord.

## Is this a breaking change (Yes/No):

No.

## Additional Information

- Discord webhook action
  https://github.com/marketplace/actions/discord-webhook-action

> [!WARNING]
> Repository secret var `DISCORD_WEBHOOK_URL_WORKFLOW` is required (already added)

## Before submitting

- [x] I have read the [Contribution Guidelines](https://github.com/iputapp/lounas/blob/develop/.github/CONTRIBUTING.md).
- [x] I agree to the [Code of Conduct](https://github.com/iputapp/lounas/blob/develop/.github/CODE_OF_CONDUCT.md).
