### PR TITLE
ci(dependabot): set interval to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
     target-branch: "develop"
     ignore:


### PR DESCRIPTION
## Description

set dependabot schedule interval to daily. (previous is weekly)

## Is this a breaking change (Yes/No):

No.

## Before submitting

- [x] I have read the [Contribution Guidelines](https://github.com/iputapp/lounas/blob/develop/.github/CONTRIBUTING.md).
- [x] I agree to the [Code of Conduct](https://github.com/iputapp/lounas/blob/develop/.github/CODE_OF_CONDUCT.md).
