### PR TITLE
ci: fix can not approve your own prs of weekly merge main

### DIFF
--- a/.github/workflows/schedule-merge-main.yml
+++ b/.github/workflows/schedule-merge-main.yml
@@ -1,7 +1,7 @@
 name: Schedule merge from develop into main
 on:
   schedule:
-    - cron: "0 15 * * 0" # Every Monday at 00:00 JST
+    - cron: "0 0 * * 1" # Every Monday at 09:00 JST
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/schedule-merge-main.yml
+++ b/.github/workflows/schedule-merge-main.yml
@@ -33,14 +33,20 @@ jobs:
       - name: Approve a PR
         # Only approve if PR has diff
         if: ${{ steps.diff.outcome == 'failure' }}
-        run: gh pr review --approve "$PR_URL"
+        run: |
+          git config user.name  "iputapp[bot]"
+          git config user.email "185724386+iputapp-bot@users.noreply.github.com"
+          gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ steps.pull-request.outputs.PR_URL }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable auto-merge for PRs
         # Only merge if PR has diff
         if: ${{ steps.diff.outcome == 'failure' }}
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: |
+          git config user.name  "iputapp[bot]"
+          git config user.email "185724386+iputapp-bot@users.noreply.github.com"
+          gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ steps.pull-request.outputs.PR_URL }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

fix can not approve your own prs of weekly merge main workflow.

## Is this a breaking change (Yes/No):

No.

## Additional Information

approve and merge user -> https://github.com/iputapp-bot

## Before submitting

- [x] I have read the [Contribution Guidelines](https://github.com/iputapp/lounas/blob/develop/.github/CONTRIBUTING.md).
- [x] I agree to the [Code of Conduct](https://github.com/iputapp/lounas/blob/develop/.github/CODE_OF_CONDUCT.md).
